### PR TITLE
Fix three bugs

### DIFF
--- a/src/query/init.c
+++ b/src/query/init.c
@@ -62,7 +62,7 @@ static int LTS_query_new(lua_State *L) {
 	const char *src = luaL_checklstring(L, 2, &src_len);
 
 	uint32_t err_offset = 0;
-	TSQueryError err_type;
+	TSQueryError err_type = TSQueryErrorNone;
 	TSQuery *self = ts_query_new(lang, src, src_len, &err_offset, &err_type);
 	switch (err_type) {
 	case TSQueryErrorNone: break;

--- a/src/query/runner.c
+++ b/src/query/runner.c
@@ -59,7 +59,7 @@ static int LTS_query_runner_new(lua_State *L) {
 
 static int LTS_query_runner_delete(lua_State *L) {
 	LTS_QueryRunner self = *LTS_log_gc(LTS_check_query_runner(L, 1), LTS_QUERY_RUNNER_METATABLE_NAME);
-	
+
 	luaL_unref(L, LUA_REGISTRYINDEX, self.predicates_ref);
 	return 0;
 }
@@ -96,6 +96,7 @@ static bool run_predicates(
 		lua_pushlstring(L, name, len);
 		lua_rawget(L, predicates_idx);
 
+		lua_checkstack(L, count);
 		for (; i < count; i++) {
 			TSQueryPredicateStep step = steps[i];
 			switch (step.type) {


### PR DESCRIPTION
### fix(parser): fix missing error message on reader function fail
The error returned by `Parser:read` used to be `error while executing read function: (null)` before this fix, due to the error object pushed by `lua_pcall` being popped by the `fail` block.

### fix(query_runner): ensure enough stack space for predicate arguments
[Example query that fails without this fix.](https://github.com/tree-sitter-grammars/tree-sitter-lua/blob/e5e406935ff3e36529545955e2972646ed97f9e2/queries/highlights.scm#L207) Note that the default Lua stack frame size is 20.

### fix(query): initialize ts_query_new error type variable to none
Per [the official documentation](https://tree-sitter.github.io/tree-sitter/using-parsers/queries/4-api.html), `ts_query_new` sets the `error_offset` and `error_type` arguments, **if** an error occurred. In particular, it does not have to do so, when no error is encountered. A concrete failing test case is an empty string.